### PR TITLE
Increased Task Limit

### DIFF
--- a/src/components/App/Tracker/Day.tsx
+++ b/src/components/App/Tracker/Day.tsx
@@ -299,7 +299,7 @@ const Day: React.FC<{ date: string; user: User }> = ({ date, user }) => {
       ))}
       {/* add a task */}
       <Flex align="center" gap={1}>
-        {tasks.length < 5 && (
+        {tasks.length < 10 && (
           <Icon
             as={MdAdd}
             color={isCurrentDay ? "#342552" : "gray.400"}

--- a/src/hooks/useTasks.tsx
+++ b/src/hooks/useTasks.tsx
@@ -29,7 +29,7 @@ const useTasks = (date: string, user: User) => {
     date: string,
     color: string
   ) => {
-    if (tasks.length < 5) {
+    if (tasks.length < 10) {
       const taskToAdd: Task = {
         id: "",
         text: task,


### PR DESCRIPTION
**Task:**
Increase Task Limit to 10 Tasks/day

**Why:**
Give users more freedom to add more tasks of their choice.

**How:**
- Adjusted `tasks.length` on line 32 in the `useTasks.tsx` file from 5 to 10
- Adjusted `tasks.length` on line 302 in the `Day.tsx` file from 5 to 10